### PR TITLE
Fix #8 archive year number bug for CleanPress

### DIFF
--- a/cleanpress/index.liquid
+++ b/cleanpress/index.liquid
@@ -169,7 +169,7 @@
     {% block archives_page %}
       {% block archives %}
       <section class="archives">
-        <h1 class="year">2013</h1>
+        <h1 class="year">{{archive.year}}</h1>
 
         {% block posts %}
         <article>


### PR DESCRIPTION
Fixes issue #8 about wrong year numbering in archive view for theme CleanPress.

The `archives` section mistakenly hard-coded year number as 2013.
Correct it by referencing other theme's (specifically, Frankies) code.
